### PR TITLE
Adds github OAuth to user dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'omniauth-google-oauth2'
 gem 'will_paginate'
 gem 'acts-as-taggable-on', '~> 6.0'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
+gem 'omniauth-github'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-github (1.3.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-google-oauth2 (0.6.1)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -354,6 +357,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   omniauth-census!
+  omniauth-github
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,8 @@ class ApplicationController < ActionController::Base
   def four_oh_four
     raise ActionController::RoutingError.new('Not Found')
   end
+
+  def require_login
+    redirect_to root_path unless current_user
+  end
 end

--- a/app/controllers/github/sessions_controller.rb
+++ b/app/controllers/github/sessions_controller.rb
@@ -1,0 +1,19 @@
+class Github::SessionsController < ApplicationController
+  before_action :require_login
+
+  def create
+    current_user.update(github_extraction)
+    redirect_to dashboard_path
+  end
+
+  private
+
+  # Might want to change to model method?
+  def github_extraction
+    github_info = {}
+    omniauth_info = request.env['omniauth.auth']
+    github_info[:uid] = omniauth_info.uid
+    github_info[:github_token] = omniauth_info.credentials.token
+    github_info
+  end
+end

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -4,9 +4,7 @@ module OmniauthHelper
 
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
       provider: 'github',
-      extra: {
-
-      },
+      uid: "1234",
       credentials: {
         token: 'github_token_goes_here'
       }

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -1,0 +1,15 @@
+module OmniauthHelper
+  def stub_github
+    OmniAuth.config.test_mode = true
+
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+      provider: 'github'.
+      extra: {
+
+      },
+      credentials: {
+        token: 'github_token_goes_here'
+      }
+      })
+  end
+end

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -3,7 +3,7 @@ module OmniauthHelper
     OmniAuth.config.test_mode = true
 
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
-      provider: 'github'.
+      provider: 'github',
       extra: {
 
       },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password
   validates_presence_of :first_name
   enum role: [:default, :admin]
   has_secure_password

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,5 +36,7 @@
         </ul>
       </section>
     </section>
+    <% else %>
+    <%= button_to 'Connect to GitHub', github_oauth_path %>
   <% end %>
 </section>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: 'user,repo'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,4 +42,7 @@ Rails.application.routes.draw do
   end
 
   resources :user_videos, only:[:create, :destroy]
+
+  get '/auth/github', as: :github_oauth
+  get '/auth/github/callback', to: 'github/sessions#create', as: :github_callback
 end

--- a/db/migrate/20190320045818_add_uid_to_users.rb
+++ b/db/migrate/20190320045818_add_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddGithubTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :uid, :string
+  end
+end

--- a/spec/features/user/user_can_connect_github_spec.rb
+++ b/spec/features/user/user_can_connect_github_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+context 'As a user without a github token' do
+  before :each do
+    @user = create(:user)
+  end
+
+  it 'I see a link on my dashboard to connect to github' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    allow_any_instance_of(User).to receive(:github_token).and_return(nil)
+
+    visit dashboard_path
+
+    expect(page).to have_button 'Connect to GitHub'
+    expect(page).to_not have_content 'Following'
+    expect(page).to_not have_content 'Followers'
+    expect(page).to_not have_content 'battleship'
+  end
+
+  it 'I can connect my dashboard to github and see my information' do
+    # Login cannot be stubbed
+    visit login_path
+    fill_in 'session[email]', with: @user.email
+    fill_in 'session[password]', with: @user.password
+    click_button 'Log In'
+    stub_github
+
+    VCR.use_cassette('views/dashboard_github_request') do
+      click_button 'Connect to GitHub'
+
+      expect(current_path).to eq(dashboard_path)
+      expect(page).to have_content 'Following'
+      expect(page).to have_content 'Follers'
+      expect(page).to have_content 'battleship'
+    end
+  end
+end

--- a/spec/features/user/user_can_connect_github_spec.rb
+++ b/spec/features/user/user_can_connect_github_spec.rb
@@ -25,12 +25,13 @@ context 'As a user without a github token' do
     click_button 'Log In'
     stub_github
 
+
     VCR.use_cassette('views/dashboard_github_request') do
       click_button 'Connect to GitHub'
 
       expect(current_path).to eq(dashboard_path)
       expect(page).to have_content 'Following'
-      expect(page).to have_content 'Follers'
+      expect(page).to have_content 'Followers'
       expect(page).to have_content 'battleship'
     end
   end

--- a/spec/features/user/user_sees_github_on_dashboard_spec.rb
+++ b/spec/features/user/user_sees_github_on_dashboard_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe'when I visit my dashboard' do
   context 'as a user' do
     before :each do
-      user = create(:user)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      @user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       allow_any_instance_of(User).to receive(:github_token).and_return(ENV['GITHUB_API_KEY'])
     end
 
@@ -77,6 +77,35 @@ describe'when I visit my dashboard' do
             expect(page).to have_link('plapicola')
           end
         end
+      end
+    end
+
+    context 'As a user without a github token' do
+      it 'I see a link on my dashboard to connect to github' do
+        allow_any_instance_of(User).to receive(:github_token).and_return(nil)
+
+        visit dashboard_path
+
+        expect(page).to have_button 'Connect to GitHub'
+        expect(page).to_not have_content 'Following'
+        expect(page).to_not have_content 'Followers'
+        expect(page).to_not have_content 'battleship'
+      end
+
+      it 'I can connect my dashboard to github and see my information' do
+        # Login cannot be stubbed
+        visit login_path
+        fill_in :username, with: @user.email
+        fill_in :password, with: @user.password
+        click_button 'Log In'
+        stub_github
+
+        click_button 'Connect to GitHub'
+
+        expect(current_path).to eq(dashboard_path)
+        expect(page).to have_content 'Following'
+        expect(page).to have_content 'Follers'
+        expect(page).to have_content 'battleship'
       end
     end
   end

--- a/spec/features/user/user_sees_github_on_dashboard_spec.rb
+++ b/spec/features/user/user_sees_github_on_dashboard_spec.rb
@@ -79,34 +79,5 @@ describe'when I visit my dashboard' do
         end
       end
     end
-
-    context 'As a user without a github token' do
-      it 'I see a link on my dashboard to connect to github' do
-        allow_any_instance_of(User).to receive(:github_token).and_return(nil)
-
-        visit dashboard_path
-
-        expect(page).to have_button 'Connect to GitHub'
-        expect(page).to_not have_content 'Following'
-        expect(page).to_not have_content 'Followers'
-        expect(page).to_not have_content 'battleship'
-      end
-
-      it 'I can connect my dashboard to github and see my information' do
-        # Login cannot be stubbed
-        visit login_path
-        fill_in :username, with: @user.email
-        fill_in :password, with: @user.password
-        click_button 'Log In'
-        stub_github
-
-        click_button 'Connect to GitHub'
-
-        expect(current_path).to eq(dashboard_path)
-        expect(page).to have_content 'Following'
-        expect(page).to have_content 'Follers'
-        expect(page).to have_content 'battleship'
-      end
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  config.include OmniauthHelper
+
   config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Adds ability for users without GitHub tokens in the database to connect to github in order to see their github info on their dashboard via a button on the dashboard for the user.

@jmejia If you have any input on the first pass of this function, especially regarding where something like the data extraction would live it would be awesome.