### PR TITLE
Empty Tutorial Bugfix

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -6,7 +6,8 @@ class TutorialsController < ApplicationController
   end
 
   def show
-    tutorial = Tutorial.find(params[:id])
-    @facade = TutorialFacade.new(tutorial, params[:video_id])
+    render locals: {
+      facade: TutorialFacade.new(params[:id], params[:video_id])
+    }
   end
 end

--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -1,15 +1,11 @@
 class TutorialFacade < SimpleDelegator
-  def initialize(tutorial, video_id = nil)
-    super(tutorial)
-    @video_id = video_id
+  def initialize(tutorial_id, video_id = nil)
+    super(Tutorial.find(tutorial_id))
+    @video = Video.find_by(id: video_id) || videos.first
   end
 
   def current_video
-    if @video_id
-      videos.find(@video_id)
-    else
-      videos.first
-    end
+    @video || Video.new
   end
 
   def next_video
@@ -20,10 +16,14 @@ class TutorialFacade < SimpleDelegator
     !(current_video.position >= maximum_video_position)
   end
 
+  def player_partial
+    videos.empty? ? 'empty_tutorial' : 'player'
+  end
+
   private
 
   def current_video_index
-    videos.index(current_video)
+    videos.index(current_video) || 0
   end
 
   def maximum_video_position

--- a/app/views/tutorials/_empty_tutorial.html.erb
+++ b/app/views/tutorials/_empty_tutorial.html.erb
@@ -1,0 +1,4 @@
+<div class="col col-8">
+  <h1>This tutorial is currently empty.</h1>
+  <p>Please check back later.</p>
+</div>

--- a/app/views/tutorials/_player.html.erb
+++ b/app/views/tutorials/_player.html.erb
@@ -1,0 +1,48 @@
+<div class="col col-8">
+  <div class="title-bookmark">
+    <h3><%= facade.current_video.title %></h3>
+    <div class="bookmarks-btn">
+      <%= button_to "Bookmark", user_videos_path(video_id: facade.current_video.id), method: :post, class: "btn btn-outline mb1 teal" %>
+    </div>
+  </div>
+
+  <div id="player">
+    <script src="https://www.youtube.com/player_api"></script>
+    <script>
+    // create youtube player
+    var player;
+    var position;
+    function onYouTubePlayerAPIReady() {
+      player = new YT.Player('player', {
+        width: '640',
+        height: '390',
+        videoId: '<%= facade.current_video.video_id %>',
+        events: {
+          onReady: onPlayerReady,
+          onStateChange: onPlayerStateChange
+        }
+      });
+    }
+
+    // autoplay video
+    function onPlayerReady(event) {
+      event.target.playVideo();
+    }
+
+    // when video ends
+    function onPlayerStateChange(event) {
+      if(event.data === 0 && <%= facade.play_next_video? %>) {
+        window.location = "/tutorials/<%=facade.id%>?video_id=<%=facade.next_video.id %>";
+      } else if(event.data === 0 && <%= facade.play_next_video? == false %>) {
+        const message = document.querySelector(`#message`);
+        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+      }
+    }
+  </script>
+</div>
+  <h4>Description</h4>
+  <p data-controller="tutorials" id="description-<%= facade.current_video.id %>">
+    <%= facade.current_video.description.truncate(50) %>...
+    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: facade.current_video.id, class: "show-link"%>
+  </p>
+</div>

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,10 +1,10 @@
 <main class="tutorials">
-<h2><%= @facade.title %></h2>
+<h2><%= facade.title %></h2>
 <h1 id="message"></h1>
 <div class="col col-4">
   <h4>Videos</h4>
   <ul>
-    <% @facade.videos.each do |video| %>
+    <% facade.videos.each do |video| %>
       <li>
         <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
       </li>
@@ -12,54 +12,6 @@
   </ul>
 </div>
 
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id), method: :post, class: "btn btn-outline mb1 teal" %>
-    </div>
-  </div>
-
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
-        }
-      });
-    }
-
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
-
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
-      }
-    }
-  </script>
-</div>
-
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
-</div>
+<%= render partial: facade.player_partial, locals: {facade: facade} %>
 
 </main>

--- a/spec/features/vistors/vistor_sees_a_video_show_spec.rb
+++ b/spec/features/vistors/vistor_sees_a_video_show_spec.rb
@@ -13,4 +13,13 @@ describe 'visitor sees a video show' do
     expect(page).to have_content(video.title)
     expect(page).to have_content(tutorial.title)
   end
+
+  it 'visitor sees a notice that there are no videos in an empty tutorial' do
+    tutorial = create(:tutorial)
+
+    visit tutorial_path(tutorial)
+    save_and_open_page
+
+    expect(page).to have_content("This tutorial is currently empty.")
+  end
 end

--- a/spec/presenters/tutorial_presenter_spec.rb
+++ b/spec/presenters/tutorial_presenter_spec.rb
@@ -7,7 +7,7 @@ describe TutorialFacade do
       video2 = create(:video, tutorial_id: tutorial.id)
       video3 = create(:video, tutorial_id: tutorial.id)
 
-      presenter = TutorialFacade.new(tutorial, video2.id)
+      presenter = TutorialFacade.new(tutorial.id, video2.id)
 
       expect(presenter.current_video.id).to eq(video2.id)
     end
@@ -18,7 +18,7 @@ describe TutorialFacade do
       video2 = create(:video, tutorial_id: tutorial.id)
       video3 = create(:video, tutorial_id: tutorial.id)
 
-      presenter = TutorialFacade.new(tutorial)
+      presenter = TutorialFacade.new(tutorial.id)
 
       expect(presenter.current_video.id).to eq(video1.id)
     end
@@ -30,7 +30,7 @@ describe TutorialFacade do
         video2 = create(:video, tutorial_id: tutorial.id, position: 2)
         video3 = create(:video, tutorial_id: tutorial.id, position: 3)
 
-        presenter = TutorialFacade.new(tutorial, video1.id)
+        presenter = TutorialFacade.new(tutorial.id, video1.id)
 
         expect(presenter.next_video).to eq(video2)
       end
@@ -40,7 +40,7 @@ describe TutorialFacade do
         rocky = create(:video, tutorial: learn_to_fight, position: 1)
         bloodsport = create(:video, tutorial: learn_to_fight, position: 2)
 
-        presenter = TutorialFacade.new(learn_to_fight, bloodsport.id)
+        presenter = TutorialFacade.new(learn_to_fight.id, bloodsport.id)
         expect(presenter.next_video).to eq(bloodsport)
       end
     end


### PR DESCRIPTION
- Adds partials for youtube player on tutorial show page and adjusts initialization logic for TutorialFacade to better handle situations where the tutorial contains no videos.

- Adds a partial/alternate view for the page that indicates the tutorial contains no videos and instructs the user to check back later.